### PR TITLE
[FIX][OpenUpgrade]:

### DIFF
--- a/odoo/addons/base/migrations/10.0.1.3/pre-migration.py
+++ b/odoo/addons/base/migrations/10.0.1.3/pre-migration.py
@@ -285,7 +285,9 @@ def migrate(cr, version):
             ('trescloud_partner_related_phone_meet_opportunity','l10n_ec'),
             ('trescloud_remove_traduction_product','l10n_ec'),
             ('trescloud_tax_free_improvement','l10n_ec'),
-            ('trescloud_mp_sales','l10n_ec')
+            ('trescloud_mp_sales','l10n_ec'),
+            ('multipruss_reports','l10n_ec'),
+            ('trescloud_bank_account_type','l10n_ec'),
         ], merge_modules=True,
     )
     openupgrade.update_module_names(


### PR DESCRIPTION
Corregido mapeo de modulos de multipruss por problemas al actualizar de V10 a V10T

Modulos eliminados:
"multipruss_reports": https://github.com/TRESCLOUD/odoo-clientes-especificos/tree/PROD07-2018-03/MULTIPRUSS/multipruss_reports
"trescloud_bank_account_type": https://github.com/TRESCLOUD/odoo-ecuador-rrhh/tree/PROD07-2018-03/trescloud_bank_account_type
